### PR TITLE
Added github templates folder

### DIFF
--- a/.github/Contribute.md
+++ b/.github/Contribute.md
@@ -1,0 +1,23 @@
+# Cum contribui?
+
+## Ai găsit un bug?
+
+- Caută bug-ul in Github Issues.
+- Dacă nu ai găsit bug-ul, creează unul nou. Titlul și descrierea trebuie să conțină informații relevante și o metodă de reproducere care să demonstreze comportamentul nedorit.
+
+## Ai scris cod care repară un bug?
+
+- Deschide un pull request.
+- Pull-requestul trebuie sa descrie clar problema și să includă Github Issue id.
+- Înainte să trimiți, verifică coding style-ul și rulează testele.
+
+## Funcționalitate nouă sau modifici una existentă?
+
+- Propune modificarea pe [slack](https://govithub.slack.com/messages/socent) în canalul proiectului.
+- Discută cu alți contribuitori modificarea.
+- Toate schimbările trebuie să fie într-un branch separat, nu în master.
+- Un branch ajunge în master în urma unui pull request cu cel puțin un code review.
+
+## Securitate
+
+- Problemele grave de securitate trebuie raportate prin mail sau direct message pe Slack.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Expected behavior
+
+### Actual behavior
+
+### Steps to reproduce the problem.
+
+### Specifications
+version of the project:  
+operating system:  
+npm version:  
+node version:  

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+#### Fixes #...
+
+#### Here are the changes I propose:
+
+#### Test plan:
+
+#### Suggested reviewers: @gov-ithub/socent, @...


### PR DESCRIPTION
#### Here are the changes I propose:
Adding these templates will hint the user with regards to the information he has to include in his issues or pull requests. 
It also has default suggested reviewers. 
Shamelessly copied it from `socent-frontend` :)

#### Suggested reviewers: @gov-ithub/socent, @rusanu 